### PR TITLE
Adds hotels, jwt toggle, narration, utility improvements

### DIFF
--- a/config/environment.dev.ts
+++ b/config/environment.dev.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  devHost:"http://localhost:3000"
+  devHost:"http://localhost:3000",
+  baseApiUrl: "http://localhost:8080"
 };

--- a/config/environment.dev.ts
+++ b/config/environment.dev.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  devHost:"http://localhost:3000",
-  baseApiUrl: "http://localhost:8080"
+  baseApiUrl: "http://localhost:8080",
+  jwtEnabled: true
 };

--- a/src/app/+hotels/hotels.component.html
+++ b/src/app/+hotels/hotels.component.html
@@ -6,24 +6,24 @@
         [class.has-error]="!hotelForm.valid">
 
     <div class="form-group"
-        [class.has-error]="!hotelForm.find('location').valid">
-      <label for="locationInput">Location</label>
-      <input type="text"
-             id="locationInput"
-             placeholder="City name"
-             #loc="ngForm"
-             [ngFormControl]="hotelForm.controls['location']"
-             class="form-control">
-    </div>
-
-    <div class="form-group"
       [class.has-error]="!hotelForm.find('description').valid">
       <label for="descriptionInput">Description</label>
       <input type="text"
              id="descriptionInput"
-             placeholder="enter a keyword"
+             placeholder="enter an optional keyword"
              #desc="ngForm"
              [ngFormControl]="hotelForm.controls['description']"
+             class="form-control">
+    </div>
+
+    <div class="form-group"
+        [class.has-error]="!hotelForm.find('location').valid">
+      <label for="locationInput">Location</label>
+      <input type="text"
+             id="locationInput"
+             placeholder="eg. 'London', 'United States', 'California'..."
+             #loc="ngForm"
+             [ngFormControl]="hotelForm.controls['location']"
              class="form-control">
     </div>
 

--- a/src/app/+hotels/hotels.component.html
+++ b/src/app/+hotels/hotels.component.html
@@ -1,7 +1,10 @@
 <div class="panel panel-default">
-  <h2 class="panel-heading">Find Hotels</h2>
+  <div class="panel-heading">
+      <h3>Find Hotels</h3>
+  </div>
+  <div class="panel-body">
   <form [ngFormModel]="hotelForm"
-        (ngSubmit)="onSubmit(hotelForm.value)"
+        (ngSubmit)="findHotels(hotelForm.value)"
         class="form-inline"
         [class.has-error]="!hotelForm.valid">
 
@@ -10,7 +13,7 @@
       <label for="descriptionInput">Description</label>
       <input type="text"
              id="descriptionInput"
-             placeholder="enter an optional keyword"
+             placeholder="optional keyword"
              #desc="ngForm"
              [ngFormControl]="hotelForm.controls['description']"
              class="form-control">
@@ -21,7 +24,7 @@
       <label for="locationInput">Location</label>
       <input type="text"
              id="locationInput"
-             placeholder="eg. 'London', 'United States', 'California'..."
+             placeholder="eg. 'London', 'France'..."
              #loc="ngForm"
              [ngFormControl]="hotelForm.controls['location']"
              class="form-control">
@@ -29,4 +32,43 @@
 
     <button type="submit" class="btn btn-primary btn-sm">Find Hotels</button>
   </form>
+</div>
+</div>
+
+<div class="panel panel-default" *ngIf="data">
+    <div class="panel-heading">
+        <h3 class="panel-title">Matching POIs</h3>
+    </div>
+    <div class="panel-body">
+        <div *ngIf="data.length == 0">
+            No matching POI
+        </div>
+        <table *ngIf="data.length > 0" class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Address</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let line of data">
+                    <td class="header">{{line.name}}</td>
+                    <td>{{line.address}}</td>
+                    <td>{{line.description}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="panel-footer">
+        <span *ngIf="data.length">
+        {{data.length}} matching point of interests (note that some might not be hotels).</span>
+    </div>
+</div>
+
+<div class="has-error" *ngIf="error && error.message">
+    <div class="help-block">There was an error (<a data-toggle="collapse" data-target="#errorDetail">click for details</a>)
+    </div>
+
+    <div id="errorDetail" class="collapse">{{error | json}}</div>
 </div>

--- a/src/app/+hotels/hotels.component.html
+++ b/src/app/+hotels/hotels.component.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 
-<div class="has-error" *ngIf="error && error.message">
+<div class="has-error" *ngIf="error">
     <div class="help-block">There was an error (<a data-toggle="collapse" data-target="#errorDetail">click for details</a>)
     </div>
 

--- a/src/app/+hotels/hotels.component.html
+++ b/src/app/+hotels/hotels.component.html
@@ -1,3 +1,32 @@
-<p>
-  hotels works!
-</p>
+<div class="panel panel-default">
+  <h2 class="panel-heading">Find Hotels</h2>
+  <form [ngFormModel]="hotelForm"
+        (ngSubmit)="onSubmit(hotelForm.value)"
+        class="form-inline"
+        [class.has-error]="!hotelForm.valid">
+
+    <div class="form-group"
+        [class.has-error]="!hotelForm.find('location').valid">
+      <label for="locationInput">Location</label>
+      <input type="text"
+             id="locationInput"
+             placeholder="City name"
+             #loc="ngForm"
+             [ngFormControl]="hotelForm.controls['location']"
+             class="form-control">
+    </div>
+
+    <div class="form-group"
+      [class.has-error]="!hotelForm.find('description').valid">
+      <label for="descriptionInput">Description</label>
+      <input type="text"
+             id="descriptionInput"
+             placeholder="enter a keyword"
+             #desc="ngForm"
+             [ngFormControl]="hotelForm.controls['description']"
+             class="form-control">
+    </div>
+
+    <button type="submit" class="btn btn-primary btn-sm">Find Hotels</button>
+  </form>
+</div>

--- a/src/app/+hotels/hotels.component.ts
+++ b/src/app/+hotels/hotels.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Injectable, Inject } from '@angular/core';
 import {
   CORE_DIRECTIVES,
   FORM_DIRECTIVES,
@@ -6,6 +6,9 @@ import {
   ControlGroup,
   Validators
 } from '@angular/common';
+import { UtilityService } from "../shared/utility.service";
+import { environment } from "../";
+
 
 @Component({
   moduleId: module.id,
@@ -14,14 +17,19 @@ import {
   templateUrl: 'hotels.component.html'
 })
 
-export class HotelsComponent implements OnInit {
-  hotelForm: ControlGroup;
+@Injectable()
 
-  constructor(fb: FormBuilder) {
+export class HotelsComponent implements OnInit {
+
+  hotelForm: ControlGroup;
+  utility: UtilityService;
+
+  constructor(fb: FormBuilder, utility: UtilityService) {
     this.hotelForm = fb.group({
-      'location':  ['', Validators.required],
-      'description': ['', Validators.required]
+       'description': [''],
+      'location':  ['']
     });
+    this.utility = utility;
   }
 
   ngOnInit() {
@@ -29,5 +37,21 @@ export class HotelsComponent implements OnInit {
 
   onSubmit(value: any): void {
     console.log('you searched for hotel:', value);
+    var location = value.location;
+    var description = value.description;
+
+    var url = environment.baseApiUrl + "/api/hotel/";
+    if (description != null && description != "") {
+        url = url + description + "/";
+        if (location != null && location != "") {
+            url = url + location + "/";
+        }
+    }
+
+    this.utility.makeGetRequestObs(url, [])
+    .subscribe(
+        (success) => { console.log(success); },
+        (error) => { console.log(error.json()); }
+    );
   }
 }

--- a/src/app/+hotels/hotels.component.ts
+++ b/src/app/+hotels/hotels.component.ts
@@ -1,15 +1,33 @@
 import { Component, OnInit } from '@angular/core';
+import {
+  CORE_DIRECTIVES,
+  FORM_DIRECTIVES,
+  FormBuilder,
+  ControlGroup,
+  Validators
+} from '@angular/common';
 
 @Component({
   moduleId: module.id,
   selector: 'app-hotels',
+  directives: [CORE_DIRECTIVES, FORM_DIRECTIVES],
   templateUrl: 'hotels.component.html'
 })
-export class HotelsComponent implements OnInit {
 
-  constructor() {}
+export class HotelsComponent implements OnInit {
+  hotelForm: ControlGroup;
+
+  constructor(fb: FormBuilder) {
+    this.hotelForm = fb.group({
+      'location':  ['', Validators.required],
+      'description': ['', Validators.required]
+    });
+  }
 
   ngOnInit() {
   }
 
+  onSubmit(value: any): void {
+    console.log('you searched for hotel:', value);
+  }
 }

--- a/src/app/+hotels/hotels.component.ts
+++ b/src/app/+hotels/hotels.component.ts
@@ -67,31 +67,26 @@ export class HotelsComponent implements OnInit, OnDestroy {
     .map((response: Response) => response.json())
     .subscribe(
         (val) => {
-            this.data = val;
-            this.error = null;
+            this.data = val.data;
 
-            let executedQuery = {"query":{"conjuncts": [
-    {"field":"type","term":"landmark"},
-    {"disjuncts":[
-        {"field":"country","match_phrase":"France"},
-        {"field":"city","match_phrase":"France"},
-        {"field":"state","match_phrase":"France"},
-        {"field":"address","match_phrase":"France"}
-    ]},
-    {"field":"content","match":"hotel"},
-    {"disjuncts":[
-        {"field":"content","match_phrase":"golf"},
-        {"field":"name","match_phrase":"golf"}
-    ]}
-]},
-"size":100};
+            //we expect 2 context requests
+            if (val.context.length == 2) {
+                this._narrations.addPre("FTS query executed in the backend", "The following FTS query was executed in the backend:", val.context[0]);
+                this._narrations.addPre("Subdocument query executed in the backend", "The following subdocument fetch was executed in the backend:", val.context[1]);
+                this._narrations.add("SUCCESS", "Found " + this.data.length + " matching hotels");
+            } else {
+                this._narrations.fallbackPre(2, "SUCCESS (found " + this.data.length + " matching hotels)", val.context);
+            }
 
-            this._narrations.addPre("SUCCESS: Found " + val.length + " matching hotels", "The following FTS query was executed in the backend:", JSON.stringify(executedQuery, null, 2));
+
         },
         (error: Response) => {
             this.data = null;
             this.error = error.json();
-            this._narrations.add("ERROR", error.json());
+            if (this.error.failure) {
+                this.error = this.error.failure;
+            }
+            this._narrations.addPre("ERROR", "There was an error:", JSON.stringify(this.error, null, 2));
         }
     );
   }

--- a/src/app/+hotels/hotels.component.ts
+++ b/src/app/+hotels/hotels.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Injectable, Inject } from '@angular/core';
+import { Component, OnInit, OnDestroy, Injectable, Inject } from '@angular/core';
 import {
   CORE_DIRECTIVES,
   FORM_DIRECTIVES,
@@ -7,8 +7,8 @@ import {
   Validators
 } from '@angular/common';
 import { Response } from "@angular/http";
-
 import { UtilityService } from "../shared/utility.service";
+import { Narration, NarrationService } from "../shared/narration.service";
 import { environment } from "../";
 import { Observable } from 'rxjs/Rx';
 
@@ -21,51 +21,77 @@ import { Observable } from 'rxjs/Rx';
 
 @Injectable()
 
-export class HotelsComponent implements OnInit {
+export class HotelsComponent implements OnInit, OnDestroy {
 
   hotelForm: ControlGroup;
   utility: UtilityService;
+  private _narrations: NarrationService;
   data;
   error;
 
-  constructor(fb: FormBuilder, utility: UtilityService) {
+  constructor(fb: FormBuilder, utility: UtilityService, narrationService: NarrationService) {
     this.hotelForm = fb.group({
        'description': [''],
-      'location':  ['']
+       'location':  ['']
     });
     this.utility = utility;
+    this._narrations = narrationService;
   }
 
   ngOnInit() {
+      this._narrations.add("Entered Hotels component", "You navigated to the Hotels search form");
+  }
+
+  ngOnDestroy() {
+      this._narrations.clear();
   }
 
   findHotels(value: any): void {
-    console.log('you searched for hotel:', value);
-    var location = value.location;
-    var description = value.description;
+      var location = value.location;
+      var description = value.description;
 
-    var url = environment.baseApiUrl + "/api/hotel/";
-    var hasDescription = (description != null && description != "");
-    var hasLocation = (location != null && location != "");
-    if (hasDescription && hasLocation) {
-        url = url + description + "/" + location + "/";
-    } else if (hasLocation) {
-        url = url + "*/" + location + "/";
-    } else if (hasDescription) {
-        url = url + description + "/"
-    }
+      var url = environment.baseApiUrl + "/api/hotel/";
+      var hasDescription = (description != null && description != "");
+      var hasLocation = (location != null && location != "");
+      if (hasDescription && hasLocation) {
+          url = url + description + "/" + location + "/";
+      } else if (hasLocation) {
+          url = url + "*/" + location + "/";
+      } else if (hasDescription) {
+          url = url + description + "/"
+      }
+
+      this._narrations.addPre("GET to " + url, "The search parameters were:", JSON.stringify(value));
 
     this.utility.makeGetRequestObs(url, [])
     .map((response: Response) => response.json())
     .subscribe(
-        (success) => {
-            console.log("DEBUG: found " + success.length + " matching hotels");
-            this.data = success;
+        (val) => {
+            this.data = val;
             this.error = null;
+
+            let executedQuery = {"query":{"conjuncts": [
+    {"field":"type","term":"landmark"},
+    {"disjuncts":[
+        {"field":"country","match_phrase":"France"},
+        {"field":"city","match_phrase":"France"},
+        {"field":"state","match_phrase":"France"},
+        {"field":"address","match_phrase":"France"}
+    ]},
+    {"field":"content","match":"hotel"},
+    {"disjuncts":[
+        {"field":"content","match_phrase":"golf"},
+        {"field":"name","match_phrase":"golf"}
+    ]}
+]},
+"size":100};
+
+            this._narrations.addPre("SUCCESS: Found " + val.length + " matching hotels", "The following FTS query was executed in the backend:", JSON.stringify(executedQuery, null, 2));
         },
         (error: Response) => {
             this.data = null;
             this.error = error.json();
+            this._narrations.add("ERROR", error.json());
         }
     );
   }

--- a/src/app/+hotels/hotels.component.ts
+++ b/src/app/+hotels/hotels.component.ts
@@ -6,9 +6,11 @@ import {
   ControlGroup,
   Validators
 } from '@angular/common';
+import { Response } from "@angular/http";
+
 import { UtilityService } from "../shared/utility.service";
 import { environment } from "../";
-
+import { Observable } from 'rxjs/Rx';
 
 @Component({
   moduleId: module.id,
@@ -23,6 +25,8 @@ export class HotelsComponent implements OnInit {
 
   hotelForm: ControlGroup;
   utility: UtilityService;
+  data;
+  error;
 
   constructor(fb: FormBuilder, utility: UtilityService) {
     this.hotelForm = fb.group({
@@ -35,23 +39,33 @@ export class HotelsComponent implements OnInit {
   ngOnInit() {
   }
 
-  onSubmit(value: any): void {
+  findHotels(value: any): void {
     console.log('you searched for hotel:', value);
     var location = value.location;
     var description = value.description;
 
     var url = environment.baseApiUrl + "/api/hotel/";
-    if (description != null && description != "") {
-        url = url + description + "/";
-        if (location != null && location != "") {
-            url = url + location + "/";
-        }
+    var hasDescription = (description != null && description != "");
+    var hasLocation = (location != null && location != "");
+    if (hasDescription && hasLocation) {
+        url = url + description + "/" + location + "/";
+    } else if (hasLocation) {
+        url = url + "*/" + location + "/";
+    } else if (hasDescription) {
+        url = url + description + "/"
     }
 
     this.utility.makeGetRequestObs(url, [])
     .subscribe(
-        (success) => { console.log(success); },
-        (error) => { console.log(error.json()); }
+        (success) => {
+            console.log("DEBUG: found " + success.length + " matching hotels");
+            this.data = success;
+            this.error = null;
+        },
+        (error: Response) => {
+            this.data = null;
+            this.error = error.json();
+        }
     );
   }
 }

--- a/src/app/+hotels/hotels.component.ts
+++ b/src/app/+hotels/hotels.component.ts
@@ -66,7 +66,7 @@ export class HotelsComponent implements OnInit, OnDestroy {
     this.utility.makeGetRequestObs(url, [])
     .map((response: Response) => response.json())
     .subscribe(
-        (val) => {
+        (val: any) => {
             this.data = val.data;
 
             //we expect 2 context requests
@@ -80,12 +80,9 @@ export class HotelsComponent implements OnInit, OnDestroy {
 
 
         },
-        (error: Response) => {
+        (error: any) => {
             this.data = null;
-            this.error = error.json();
-            if (this.error.failure) {
-                this.error = this.error.failure;
-            }
+            this.error = error;
             this._narrations.addPre("ERROR", "There was an error:", JSON.stringify(this.error, null, 2));
         }
     );

--- a/src/app/+hotels/hotels.component.ts
+++ b/src/app/+hotels/hotels.component.ts
@@ -56,6 +56,7 @@ export class HotelsComponent implements OnInit {
     }
 
     this.utility.makeGetRequestObs(url, [])
+    .map((response: Response) => response.json())
     .subscribe(
         (success) => {
             console.log("DEBUG: found " + success.length + " matching hotels");

--- a/src/app/+login/login.component.html
+++ b/src/app/+login/login.component.html
@@ -7,7 +7,7 @@
         <form role="form" class="form-signin" name="loginForm" novalidate>
         <h3 class="form-signin-heading" [hidden]="!isNew">Please Take a Moment to Create an Account</h3>
         <h3 class="form-signin-heading" [hidden]="isNew">Please Enter Your Username and Password</h3>
-        <div class="alert alert-warning" role="alert" [hidden]="!loginError">{{loginError}}</div>
+        <div class="alert alert-warning" role="alert" [hidden]="!loginError">{{loginError | json}}</div>
         <input type="text" placeholder="Please Enter Your Email Address" required [(ngModel)]="username" (keyup)="loginError=null" class="form-control" />
         <input type="password" placeholder="Enter a password" required="" [(ngModel)]="password" (keyup)="loginError=null" class="form-control" />
         <label class="checkbox">

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -4,5 +4,6 @@
 
 export const environment = {
   production: false,
-  baseApiUrl: "foo"
+  baseApiUrl: "http://localhost:3000",
+  jwtEnabled: true
 };

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -3,5 +3,6 @@
 // The build system defaults to the dev environment
 
 export const environment = {
-  production: false
+  production: false,
+  baseApiUrl: "foo"
 };

--- a/src/app/shared/index.ts
+++ b/src/app/shared/index.ts
@@ -2,3 +2,5 @@ export { AuthService } from './auth.service';
 export { UtilityService } from './utility.service';
 export { IUser } from './interfaces'
 export { NavbarComponent } from './navbar.component';
+export { NarrationComponent } from './narration.component';
+export { Narration, NarrationService } from './narration.service';

--- a/src/app/shared/narration.component.css
+++ b/src/app/shared/narration.component.css
@@ -1,0 +1,46 @@
+a {
+    cursor: pointer;
+    color: blue;
+    font-size: small;
+    font-family: monospace;
+}
+
+div.narration {
+    background-color: lightyellow;
+    color: black;
+}
+
+div.narration pre {
+    max-height: 100px;
+    overflow: auto;
+}
+
+div.narration pre.expanded {
+    max-height: none;
+}
+
+div.console {
+    background-color: black;
+    font-family: monospace;
+    color: white;
+    height: 110px;
+    overflow-y: scroll;
+}
+
+div.console li {
+    list-style-type: none;
+    cursor: pointer;
+}
+
+div.console li:hover {
+    color: yellow;
+}
+
+div.console li span.bullet {
+    font-weight: bold;
+}
+
+div.console li span.bullet.selected {
+    color: yellow;
+    text-decoration: none;
+}

--- a/src/app/shared/narration.component.html
+++ b/src/app/shared/narration.component.html
@@ -1,13 +1,14 @@
+<div *ngIf="model && model.length > 0">
 <div class="narration" [hidden]="!collapsed">(<a (click)="toggleCollapse()">Show Narration</a>)</div>
 <div class="container col-md-12" [hidden]="collapsed">
-<div class="panel panel-default narration" *ngIf="model && model.length > 0">
+<div class="panel panel-default narration">
     <div class="panel-heading narration">
         <span class="panel-title">Narration (<a (click)="toggleCollapse()">hide</a>)</span>
     </div>
     <div class="panel-body console">
         <ul>
             <li *ngFor="let narration of model"  (click)="select(narration)">
-                <span class="bullet" [class.selected]="narration == selected">&gt;</span> <span class="desc">{{narration.step}}</span></li>
+                <span class="bullet" [class.selected]="narration == selected">&gt;</span><span class="bullet selected" *ngIf="narration == selected">&gt;</span><span *ngIf="narration != selected">&nbsp;</span> <span class="desc">{{narration.step}}</span></li>
         </ul>
     </div>
     <div class="panel-body">
@@ -18,5 +19,6 @@
         </div>
         <div class="help-block" *ngIf="!selected">Click on a step above for an explanation</div>
     </div>
+</div>
 </div>
 </div>

--- a/src/app/shared/narration.component.html
+++ b/src/app/shared/narration.component.html
@@ -1,0 +1,22 @@
+<div class="narration" [hidden]="!collapsed">(<a (click)="toggleCollapse()">Show Narration</a>)</div>
+<div class="container col-md-12" [hidden]="collapsed">
+<div class="panel panel-default narration" *ngIf="model && model.length > 0">
+    <div class="panel-heading narration">
+        <span class="panel-title">Narration (<a (click)="toggleCollapse()">hide</a>)</span>
+    </div>
+    <div class="panel-body console">
+        <ul>
+            <li *ngFor="let narration of model"  (click)="select(narration)">
+                <span class="bullet" [class.selected]="narration == selected">&gt;</span> <span class="desc">{{narration.step}}</span></li>
+        </ul>
+    </div>
+    <div class="panel-body">
+        <div *ngIf="selected" class="explanation help-block">{{selected.narration}}
+            <span *ngIf="showExpandPre && expandedPre">(<a (click)="expandPre() " title="collapse">-</a>)</span>
+            <span *ngIf="showExpandPre && !expandedPre">(<a (click)="expandPre()" title="show all">+</a>)</span>
+            <pre *ngIf="selected.pre" [class.expanded]="expandedPre" (click)="expandPre()">{{selected.pre}}</pre>
+        </div>
+        <div class="help-block" *ngIf="!selected">Click on a step above for an explanation</div>
+    </div>
+</div>
+</div>

--- a/src/app/shared/narration.component.ts
+++ b/src/app/shared/narration.component.ts
@@ -1,0 +1,42 @@
+import { Component, Injectable, Inject, OnInit } from '@angular/core';
+import { Narration, NarrationService } from './narration.service'
+
+@Injectable()
+@Component({
+  moduleId: module.id,
+  selector: 'app-narration',
+  templateUrl: 'narration.component.html',
+  styleUrls: ['narration.component.css']
+})
+export class NarrationComponent implements OnInit {
+  model: Narration[];
+  selected: Narration;
+  collapsed: boolean;
+  expandedPre: boolean;
+  showExpandPre: boolean;
+  private _sharedService: NarrationService;
+
+  constructor(sharedService: NarrationService) {
+      this._sharedService = sharedService;
+  }
+
+  ngOnInit() {
+      this.model = this._sharedService.dataArray;
+      this.selected = this.model[0];
+  }
+
+  select(n: Narration) {
+      this.selected = n;
+      this.expandedPre = false;
+      this.showExpandPre = n.pre && n.pre.split(/\r\n|\r|\n/).length > 4;
+  }
+
+  toggleCollapse() {
+      this.collapsed = !this.collapsed;
+  }
+
+  expandPre() {
+      this.expandedPre = !this.expandedPre;
+  }
+
+}

--- a/src/app/shared/narration.component.ts
+++ b/src/app/shared/narration.component.ts
@@ -11,7 +11,7 @@ import { Narration, NarrationService } from './narration.service'
 export class NarrationComponent implements OnInit {
   model: Narration[];
   selected: Narration;
-  collapsed: boolean;
+  collapsed: boolean = true;
   expandedPre: boolean;
   showExpandPre: boolean;
   private _sharedService: NarrationService;

--- a/src/app/shared/narration.service.ts
+++ b/src/app/shared/narration.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Input } from '@angular/core';
+
+export class Narration {
+    public step: string;
+    public narration: string;
+    public pre: string;
+
+    constructor(s: string, n: string, pre?: string) {
+        this.step = s;
+        this.narration = n;
+        this.pre = pre ? pre : null;
+    }
+};
+
+@Injectable()
+export class NarrationService {
+    dataArray: Narration[] = [];
+
+    clear() {
+        this.dataArray.length = 0;
+    }
+
+    add(step: string, details: string) {
+        this.dataArray.push(new Narration(step, details));
+    }
+
+    addPre(step: string, details: string, pre: string) {
+        this.dataArray.push(new Narration(step, details, pre));
+    }
+}

--- a/src/app/shared/narration.service.ts
+++ b/src/app/shared/narration.service.ts
@@ -27,4 +27,15 @@ export class NarrationService {
     addPre(step: string, details: string, pre: string) {
         this.dataArray.push(new Narration(step, details, pre));
     }
+
+    fallbackPre(expectedPreCount: number, genericMessage: string, realPre: string[]) {
+        var i = 1;
+        for (var ctx of realPre) {
+            this.addPre(genericMessage +
+                " (note: expected " + expectedPreCount + " backend queries but got " + realPre.length
+                + ", " + i++ + "/" + realPre.length + ")",
+                "A query was executed in the backend:",
+                ctx);
+        }
+    }
 }

--- a/src/app/shared/utility.service.ts
+++ b/src/app/shared/utility.service.ts
@@ -74,7 +74,7 @@ export class UtilityService {
         .do((success) => {
             console.log("DEBUG: GET RESPONSE:",fullUrl,":",success.json());
         },
-            (error) => {
+        (error) => {
                 console.log("DEBUG: GET ERROR:",fullUrl,":",error);
             })
         .map(this.extractData)
@@ -82,7 +82,7 @@ export class UtilityService {
 
     private extractData(res: Response) {
         let body = res.json();
-        return body.data || { };
+        return body || { };
     }
 
     makeGetRequest(url: string, params: Array<string>) {

--- a/src/app/shared/utility.service.ts
+++ b/src/app/shared/utility.service.ts
@@ -77,18 +77,18 @@ export class UtilityService {
         (error) => {
                 console.log("DEBUG: GET ERROR:",fullUrl,":",error);
             })
-        .map(this.extractData)
     }
 
     private extractData(res: Response) {
         let body = res.json();
-        return body || { };
+        return body.data || { };
     }
 
     makeGetRequest(url: string, params: Array<string>) {
         let obs = this.makeGetRequestObs(url, params);
         return new Promise((resolve, reject) => {
             obs
+            .map(this.extractData)
             .subscribe((success) => {
                 resolve(success);
             }, (error) => {

--- a/src/app/shared/utility.service.ts
+++ b/src/app/shared/utility.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from "@angular/core";
-import { Http, Request, RequestMethod, Headers, URLSearchParams, HTTP_PROVIDERS, Response } from "@angular/http";
+import { Http, Request, RequestOptions, RequestMethod, Headers, URLSearchParams, HTTP_PROVIDERS, Response } from "@angular/http";
 import { Observable } from 'rxjs/Rx';
 import 'rxjs/add/operator/do'
 import 'rxjs/add/operator/map'
@@ -64,13 +64,22 @@ export class UtilityService {
         });
     }
 
-    makeGetRequestObs(url: string, params: Array<string>) {
+    makeGetRequestObs(url: string, params: Array<string>, searchParams?: string) {
+        let headers = new Headers({ 'Content-Type': 'application/json' });
+        let options = new RequestOptions({headers: headers});
+
         var fullUrl: string = url;
         if(params && params.length > 0) {
             fullUrl = fullUrl + "/" + params.join("/");
         }
+
+        if (searchParams) {
+            let urlSearchParams: URLSearchParams = new URLSearchParams(searchParams);
+            options.search = urlSearchParams;
+        }
+
         console.log("DEBUG: GET FULL URL:",fullUrl);
-        return this.http.get(fullUrl)
+        return this.http.get(fullUrl, options)
         .do((success) => {
             console.log("DEBUG: GET RESPONSE:",fullUrl,":",success.json());
         },

--- a/src/app/shared/utility.service.ts
+++ b/src/app/shared/utility.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, Inject } from "@angular/core";
-import { Http, Request, RequestMethod, Headers, URLSearchParams, HTTP_PROVIDERS } from "@angular/http";
+import { Http, Request, RequestMethod, Headers, URLSearchParams, HTTP_PROVIDERS, Response } from "@angular/http";
+import { Observable } from 'rxjs/Rx';
+import 'rxjs/add/operator/do'
+import 'rxjs/add/operator/map'
 
 @Injectable()
 
@@ -61,19 +64,35 @@ export class UtilityService {
         });
     }
 
-    makeGetRequest(url: string, params: Array<string>) {
+    makeGetRequestObs(url: string, params: Array<string>) {
         var fullUrl: string = url;
         if(params && params.length > 0) {
             fullUrl = fullUrl + "/" + params.join("/");
         }
         console.log("DEBUG: GET FULL URL:",fullUrl);
+        return this.http.get(fullUrl)
+        .do((success) => {
+            console.log("DEBUG: GET RESPONSE:",fullUrl,":",success.json());
+        },
+            (error) => {
+                console.log("DEBUG: GET ERROR:",fullUrl,":",error);
+            })
+        .map(this.extractData)
+    }
+
+    private extractData(res: Response) {
+        let body = res.json();
+        return body.data || { };
+    }
+
+    makeGetRequest(url: string, params: Array<string>) {
+        let obs = this.makeGetRequestObs(url, params);
         return new Promise((resolve, reject) => {
-            this.http.get(fullUrl)
+            obs
             .subscribe((success) => {
-                console.log("DEBUG: GET RESPONSE:",fullUrl,":",success.json());
-                resolve(success.json());
+                resolve(success);
             }, (error) => {
-                reject(error.json());
+                reject(error);
             });
         });
     }

--- a/src/app/shared/utility.service.ts
+++ b/src/app/shared/utility.service.ts
@@ -86,11 +86,25 @@ export class UtilityService {
         (error) => {
                 console.log("DEBUG: GET ERROR:",fullUrl,":",error);
             })
+        .catch(UtilityService.extractError);
     }
 
     private extractData(res: Response) {
         let body = res.json();
         return body.data || { };
+    }
+
+    public static extractError(res: Response): Observable<Response> {
+        let body = res.json();
+
+        if (body.failure) {
+            return Observable.throw(body.failure);
+        }
+        if (body.message) {
+            return Observable.throw(body.message);
+        }
+
+        return Observable.throw(body);
     }
 
     makeGetRequest(url: string, params: Array<string>) {

--- a/src/app/try.component.html
+++ b/src/app/try.component.html
@@ -1,5 +1,8 @@
 <div class="container">
     <div class="row">
+        <app-narration></app-narration>
+    </div>
+    <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">
                 <div class="panel-heading" [hidden]="!authService.isAuthenticated()" >

--- a/src/app/try.component.ts
+++ b/src/app/try.component.ts
@@ -5,7 +5,7 @@ import { LoginComponent } from './+login';
 import { UserComponent } from './+user';
 import { CartComponent } from './+cart';
 import { HotelsComponent } from './+hotels';
-import { AuthService,UtilityService, NavbarComponent } from './shared';
+import { AuthService,UtilityService, NavbarComponent, NarrationComponent, Narration, NarrationService } from './shared';
 import { Http, Request, RequestMethod, Headers, HTTP_PROVIDERS } from "@angular/http";
 
 @Component({
@@ -13,8 +13,8 @@ import { Http, Request, RequestMethod, Headers, HTTP_PROVIDERS } from "@angular/
   selector: 'try-app',
   templateUrl: 'try.component.html',
   styleUrls: ['try.component.css'],
-  directives: [ROUTER_DIRECTIVES, NavbarComponent],
-  providers: [ROUTER_PROVIDERS,AuthService,UtilityService,HTTP_PROVIDERS]
+  directives: [ROUTER_DIRECTIVES, NavbarComponent, NarrationComponent],
+  providers: [ROUTER_PROVIDERS,AuthService,UtilityService,NarrationService,HTTP_PROVIDERS]
 })
 @Routes([
   {path: '/home', component: HomeComponent},
@@ -26,11 +26,14 @@ import { Http, Request, RequestMethod, Headers, HTTP_PROVIDERS } from "@angular/
 export class TryAppComponent {
   router: Router;
   authService: AuthService;
-  constructor(router:Router,authService:AuthService){
+  narrationService: NarrationService;
+
+  constructor(router:Router,authService:AuthService, narrationService: NarrationService){
     this.authService=authService;
     this.router=router;
     if(!this.authService.isAuthenticated()){
       this.router.navigate(["login"]);
     }
+    this.narrationService = narrationService;
   }
 }


### PR DESCRIPTION
## hotels:

Note that the API endpoint used (/api/hotel/) is so far only
implemented in an experimental branch of try-cb-java which in turn
depends on version 2.3.0 of the Java SDK.
## jwt toggle:

add a configuration property to toggle use of JWT.
## narration:

adds a component and service that can be used with the v2 of the try-cb REST API to display narration and "behind the scene", including executed queries as notified by the backend.
## utility improvements:

getObs (HTTP GET with an Observable) can have url parameters (like /apiv/endpoint/param1/param2) and is able to extract common error patterns into the onError hook.
