### PR TITLE
Add LOWER() to N1QL queries

### DIFF
--- a/documentation/try-cb-api-spec-v2.adoc
+++ b/documentation/try-cb-api-spec-v2.adoc
@@ -105,19 +105,19 @@ See each corresponding query below.
 .(1)
 [source,sql]
 ----
-SELECT airportname from `travel-sample` WHERE faa = 'XXX';
+SELECT airportname from `travel-sample` WHERE faa = UPPER('XXX');
 ----
 
 .(2)
 [source,sql]
 ----
-SELECT airportname from `travel-sample` WHERE icao = 'YYYY';
+SELECT airportname from `travel-sample` WHERE icao = UPPER('YYYY');
 ----
 
 .(3)
 [source,sql]
 ----
-SELECT airportname from `travel-sample` WHERE airportname LIKE '%ZZZZZ';
+SELECT airportname from `travel-sample` WHERE LOWER(airportname) LIKE LOWER('%ZZZZZ%');
 ----
 
 ==== Return Codes and Values


### PR DESCRIPTION
Could do it when subbing your language specific parameters, but either way the queries need to be case insensitive or user can get quite confused.  Sending as a PR so others can weigh in on the approach.