### PR TITLE
Use dynamic host for api requests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ This application uses Angular 2.0 and typescript.  The developer environment req
 
 ## Versionning
 
-**This is version `2.0.0`**
+**This is version `2.0.1`**
 
 The aim is to build a distributable package that can be embedded in the various `try-cb` backend implementations.
 
@@ -25,24 +25,31 @@ The distribution's version number should be reflected in a tag and be also visib
 
  - [3] Make sure you have `angular-cli` installed (**this was build using angular-cli `1.0.0-beta.14`**):
 
-> `npm install -g angular-cli`
+```
+npm install -g angular-cli@1.0.0-beta.14
+```
 
  - [3] Install node dependencies, build and serve using angular-cli:
 
-> `npm install`
-> `ng serve`
-
+```
+npm install
+ng serve
+```
 
 To build a distributable version that can be embedded in a try-cb backend implementation, you can also use production mode:
 
-> `rm -rf dist/*`
-> `ng build --prod`
-> Then copy the content of `dist/` over...
+```
+rm -rf dist/*
+ng build --prod
+```
 
-**If you have globally installed an older angular-cli**:
+Then copy the content of `dist/` over to the backend application.
 
-> `npm uninstall -g angular-cli`
-> `npm cache clean`
-> `npm install -g angular-cli@latest`
+**If you have globally installed an different angular-cli**:
 
-Note the `latest` will likely evolve into something different, so you might have to force it to `1.0.0-beta14` instead if it still doesn't work...
+```
+npm uninstall -g angular-cli
+npm install -g angular-cli@1.0.0-beta.14
+```
+
+Note the `latest` version of anglular-cli doesn't work with the version that was used to build this example (1.0.0-beta14).

--- a/src/app/+cart/cart.component.ts
+++ b/src/app/+cart/cart.component.ts
@@ -45,7 +45,7 @@ export class CartComponent implements OnInit {
         "flights": [ flight ]
       };
       let user:string = this.utility.getUser();
-      let url:string = environment.devHost + "/api/user/" + user + "/flights";
+      let url:string = "/api/user/" + user + "/flights";
       this.narrationService.addPre("Authenticated POST to " + url, "The payload was:", JSON.stringify(flights));
 
       return this.utility.makePostRequest(url, [], flights, true).then((response: Response) => {

--- a/src/app/+home/home.component.ts
+++ b/src/app/+home/home.component.ts
@@ -37,7 +37,7 @@ export class HomeComponent implements OnInit {
     }
 
     public getToAirport(): Observable<string[]> {
-        return this.utility.makeGetRequestObs(environment.devHost + "/api/airports?search="+ this.to,[])
+        return this.utility.makeGetRequestObs("/api/airports?search="+ this.to,[])
         .map((result: Response) => {
                 let data = UtilityService.extractData(result) as string[];
                 let narration = UtilityService.extractNarration(result);
@@ -48,7 +48,7 @@ export class HomeComponent implements OnInit {
     }
 
     public getFromAirport():Observable<string[]> {
-      return this.utility.makeGetRequestObs(environment.devHost + "/api/airports?search="+ this.from,[])
+      return this.utility.makeGetRequestObs("/api/airports?search="+ this.from,[])
       .map((result: Response) => {
               let data = UtilityService.extractData(result) as string[];
               let narration = UtilityService.extractNarration(result);
@@ -71,11 +71,11 @@ export class HomeComponent implements OnInit {
     }
 
     public findFlights(from:string, to:string, leaves:string, returns:string):void {
-        let narrationUrl = environment.devHost + "/api/flightPaths/" + from + "/" + to + "?leave=" + leaves;
+        let narrationUrl = "/api/flightPaths/" + from + "/" + to + "?leave=" + leaves;
         this.narrationService.addSeparator("HOME: Find Flight");
         this.narrationService.add("Outbound leg GET to " + narrationUrl, "");
 
-        this.utility.makeGetRequestObs(environment.devHost + "/api/flightPaths",[from, to],"leave="+leaves)
+        this.utility.makeGetRequestObs("/api/flightPaths",[from, to],"leave="+leaves)
             .map((response: Response) => response.json())
             .subscribe(
                 (val: any) => {
@@ -96,10 +96,10 @@ export class HomeComponent implements OnInit {
             );
 
         if (returns) {
-            let narrationUrl = environment.devHost + "/api/flightPaths/" + to + "/" + from + "?leave=" + returns;
+            let narrationUrl = "/api/flightPaths/" + to + "/" + from + "?leave=" + returns;
             this.narrationService.add("Return leg GET to " + narrationUrl, "");
 
-            this.utility.makeGetRequestObs(environment.devHost + "/api/flightPaths",[to, from],"leave=" + returns)
+            this.utility.makeGetRequestObs("/api/flightPaths",[to, from],"leave=" + returns)
                 .map((response: Response) => response.json())
                 .subscribe(
                     (val: any) => {

--- a/src/app/+hotels/hotels.component.ts
+++ b/src/app/+hotels/hotels.component.ts
@@ -36,7 +36,7 @@ export class HotelsComponent implements OnInit {
       var location = value.location;
       var description = value.description;
 
-      var url = environment.devHost + "/api/hotel/";
+      var url = "/api/hotel/";
       var hasDescription = (description != null && description != "");
       var hasLocation = (location != null && location != "");
       if (hasDescription && hasLocation) {

--- a/src/app/+user/user.component.ts
+++ b/src/app/+user/user.component.ts
@@ -23,7 +23,7 @@ export class UserComponent implements OnInit {
   ngOnInit() {
       this.user = this.utility.getUser();
 
-      this.utility.makeGetRequestObs(environment.devHost + "/api/user", [this.user, "flights"], null, true)
+      this.utility.makeGetRequestObs("/api/user", [this.user, "flights"], null, true)
         .map((response: Response) => response.json())
         .subscribe(
         (val) => {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -27,7 +27,7 @@
                 </div>
                 <div class="panel-footer panel-default clearfix"><div class="row pull-right">
                     <img src="assets/poweredBy.01.png"/>
-                    <code>try-cb-frontend</code> version <code>2.0.0</code></div>
+                    <code>try-cb-frontend</code> version <code>2.0.1</code></div>
                 </div>
             </div>
         </div>

--- a/src/app/shared/auth.service.ts
+++ b/src/app/shared/auth.service.ts
@@ -32,7 +32,7 @@ export class AuthService {
 
 login(email: string, password: string) {
   return new Promise((resolve, reject) => {
-    this.utility.makePostRequest(environment.devHost + "/api/user/login", [], {"user": email, "password": md5(password)}).then((res: Response) => {
+    this.utility.makePostRequest("/api/user/login", [], {"user": email, "password": md5(password)}).then((res: Response) => {
       let result = UtilityService.extractData(res);
       if (result.token && environment.jwtEnabled) {
             try {
@@ -61,7 +61,7 @@ login(email: string, password: string) {
 register(email: string, password:string) {
   let cUser: IUser = { user: email, password: md5(password) };
   return new Promise((resolve, reject) => {
-    this.utility.makePostRequest(environment.devHost + "/api/user/signup", [], cUser).then((res: Response) => {
+    this.utility.makePostRequest("/api/user/signup", [], cUser).then((res: Response) => {
       let result = UtilityService.extractData(res);
       let narration = UtilityService.extractNarration(res);
       this.narrationService.addPre("Account Created", "The account for " + email + " was created on the server", narration[0]);

--- a/src/app/shared/utility.service.ts
+++ b/src/app/shared/utility.service.ts
@@ -14,7 +14,7 @@ export class UtilityService {
     }
 
     makePostRequest(url: string, params: Array<string>, body: Object, authenticate: boolean=false) {
-        var fullUrl: string = url;
+        var fullUrl: string = window.location.protocol + "//" + window.location.host + url;
         if(params && params.length > 0) {
             fullUrl = fullUrl + "/" + params.join("/");
         }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: true,
-  devHost: "http://localhost:8080",
   jwtEnabled: true
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: false,
-  devHost: "http://trycbBack:8080",
   jwtEnabled: true
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: false,
-  devHost: "http://localhost:8080",
   jwtEnabled: true
 };


### PR DESCRIPTION
The hardcoded environment.devHost did not work when on a remote server because CORS blocked non GET requests.

This change removed the environment.devHost setting and uses the `window.location` to work out the current host.